### PR TITLE
Added pipeline installation process

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,9 @@ If you are going to uninstall this NApp be sure to disable the current pipeline 
 Requirements
 ============
 
+This NApp needs consistency check to ensure miss flow entries installation. Ensure that ``ENABLE_CONSISTENCY_CHECK`` is `True` in the settings file from ``flow_manager``
+The following NApps are also required:
+
 - `kytos-ng/flow_manager <https://github.com/kytos-ng/flow_manager.git>`_
 - `kytos-ng/of_core <https://github.com/kytos-ng/of_core>`_
 - `MongoDB <https://github.com/kytos-ng/kytos#how-to-use-with-mongodb>`_
@@ -32,7 +35,6 @@ Subscribed
 ----------
 
 - ``kytos/flow_manager.flow.added``
-- ``kytos/of_core.handshake.completed``
 - ``kytos/flow_manager.flow.error``
 - ``kytos/[mef_eline|telemetry_int|coloring|of_lldp].enable_table``
 

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,10 @@ Overview
 
 This NApp implements Oplenflow multi tables
 
+:warning: Uninstallation :warning:
+
+If you are going to uninstall this NApp be sure to disable the current pipeline from database.
+
 Requirements
 ============
 

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -75,6 +75,10 @@ class PipelineController:
     
     def update_status(self, id: str, status: str) -> Optional[Dict]:
         """Update the status of a pipeline"""
+        if status == "enabling":
+            pipeline = self.db.pipelines.find_one({"status":"enabling"})
+            if pipeline:
+                return {"error": "Conflict"}
         utc_now = datetime.utcnow()
         pipeline = self.db.pipelines.find_one_and_update(
             {"id": id},
@@ -83,7 +87,7 @@ class PipelineController:
         )
         if not pipeline:
             return pipeline
-        if status == "enabled":
+        if status == "enabling":
             self.db.pipelines.find_one_and_update(
                 {"status": "enabled", "id": {"$ne": id}},
                 {"$set": {"status": "disabled", "updated_at": utc_now}}

--- a/db/models.py
+++ b/db/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, validator, conint
+from pydantic import BaseModel, Field, validator, conint, root_validator
 
 
 class DocumentBaseModel(BaseModel):
@@ -91,10 +91,47 @@ class MultitableDoc(BaseModel):
     description: Optional[str]
     napps_table_groups: Optional[dict[str, List[str]]]
 
+    @root_validator
+    def validate_intructions(cls, values):
+        """Validate intructions"""
+        table_miss_flow = values.get("table_miss_flow")
+        if not table_miss_flow:
+            return values
+        table_id = values["table_id"]
+        instructions = table_miss_flow.dict(exclude_none=True)["instructions"]
+        for instruction in instructions:
+            miss_table_id = instruction.get("table_id")
+            if miss_table_id is not None and miss_table_id <= table_id:
+                msg = f"Table {table_id} has a lower or equal " \
+                      f"table_id {miss_table_id} in instructions"
+                raise ValueError(msg)
+        return values
+
 class PipelineBaseDoc(DocumentBaseModel):
     """Base model for Pipeline documents"""
     status = "disabled"
     multi_table: List[MultitableDoc]
+
+    @validator("multi_table")
+    def validate_table_groups(cls, pipeline):
+        """Validate table groups"""
+        content = {}
+        for table in pipeline:
+            table_dict = table.dict(exclude_none=True)
+            table_groups = table_dict.get("napps_table_groups", {})
+            table_id = table_dict["table_id"]
+            for napp in table_groups:
+                if napp not in content:
+                    content[napp] = set(table_groups[napp])
+                else:
+                    repeated = content[napp] & set(table_groups[napp])
+                    if repeated:
+                        msg = f"Repeated {napp} table groups, {repeated}" \
+                              f" in table id: {table_id}"
+                        raise ValueError(msg)
+                    else:
+                        content[napp] |= set(table_groups[napp])
+        return pipeline
 
     @staticmethod
     def projection() -> dict:

--- a/db/models.py
+++ b/db/models.py
@@ -116,10 +116,16 @@ class PipelineBaseDoc(DocumentBaseModel):
     def validate_table_groups(cls, pipeline):
         """Validate table groups"""
         content = {}
+        id_set = set()
         for table in pipeline:
             table_dict = table.dict(exclude_none=True)
             table_groups = table_dict.get("napps_table_groups", {})
             table_id = table_dict["table_id"]
+            if table_id in id_set:
+                msg = f"Table id {table_id} repeated"
+                raise ValueError(msg)
+            else:
+                id_set.add(table_id)
             for napp in table_groups:
                 if napp not in content:
                     content[napp] = set(table_groups[napp])

--- a/main.py
+++ b/main.py
@@ -5,8 +5,8 @@ This NApp implements Oplenflow multi tables
 # pylint: disable=unused-argument, too-many-arguments, too-many-public-methods
 # pylint: disable=attribute-defined-outside-init
 import pathlib
-from threading import Lock
-from typing import Dict
+import time
+from typing import Dict, Optional
 
 import requests
 from pydantic import ValidationError
@@ -18,8 +18,8 @@ from kytos.core.rest_api import (HTTPException, JSONResponse, Request,
                                  get_json_or_400)
 
 from .controllers import PipelineController
-from .settings import (BASIC_PIPELINE, COOKIE_PREFIX, FLOW_MANAGER_URL,
-                       SUBSCRIBED_NAPPS)
+from .settings import (BATCH_INTERVAL, BATCH_SIZE, COOKIE_PREFIX,
+                       DEFAULT_PIPELINE, FLOW_MANAGER_URL, SUBSCRIBED_NAPPS)
 
 
 class Main(KytosNApp):
@@ -38,17 +38,16 @@ class Main(KytosNApp):
 
         So, if you have any setup routine, insert it here.
         """
-        self.basic_pipeline = BASIC_PIPELINE
+        self.default_pipeline = DEFAULT_PIPELINE
         self.subscribed_napps = SUBSCRIBED_NAPPS
         self.pipeline_controller = self.get_pipeline_controller()
-        self._pipeline_lock = Lock()
         self.required_napps = set()
         self.load_enable_table(self.get_enabled_table())
 
     def execute(self):
         """Execute once when the napp is running."""
 
-    def get_enabled_table(self):
+    def get_enabled_table(self) -> dict:
         """Get the only enabled table, if exists"""
         pipelines = self.pipeline_controller.get_pipelines("enabling")
         if pipelines["pipelines"]:
@@ -56,7 +55,7 @@ class Main(KytosNApp):
         pipelines = self.pipeline_controller.get_pipelines("enabled")
         if pipelines["pipelines"]:
             return pipelines["pipelines"][0]
-        return self.basic_pipeline
+        return self.default_pipeline
 
     def load_enable_table(self, pipeline: dict):
         """If a pipeline was received, set 'self' variables"""
@@ -73,7 +72,7 @@ class Main(KytosNApp):
         self.required_napps = found_napps
         self.start_enabling_pipeline(content)
 
-    def get_enabled_napps(self):
+    def get_enabled_napps(self) -> set:
         """Get the NApps that are enabled and subscribed"""
         enable_napps = set()
         for key in self.controller.napps:
@@ -90,17 +89,16 @@ class Main(KytosNApp):
         name = "enable_table"
         self.emit_event(name, content)
 
-    def build_content(self, pipeline: dict):
+    def build_content(self, pipeline: dict) -> dict:
         """Build content to be sent through an event"""
         content = {}
-        with self._pipeline_lock:
-            for table in pipeline["multi_table"]:
-                table_id = table["table_id"]
-                for napp in table["napps_table_groups"]:
-                    if napp not in content:
-                        content[napp] = {}
-                    for flow_type in table["napps_table_groups"][napp]:
-                        content[napp][flow_type] = table_id
+        for table in pipeline["multi_table"]:
+            table_id = table["table_id"]
+            for napp in table["napps_table_groups"]:
+                if napp not in content:
+                    content[napp] = {}
+                for flow_type in table["napps_table_groups"][napp]:
+                    content[napp][flow_type] = table_id
         return content
 
     def emit_event(self, name: str, content: dict = None):
@@ -126,6 +124,42 @@ class Main(KytosNApp):
             return
         self.get_flows_to_be_installed()
 
+    def get_installed_flows(self, pipeline: Dict) -> Optional[Dict]:
+        """Get flows from flow_manager"""
+        command = "v2/stored_flows?state=installed"
+        response = requests.get(f"{FLOW_MANAGER_URL}/{command}")
+
+        if response.status_code // 100 != 2:
+            # Error when enabling pipeline
+            # Return to default pipeline
+            if pipeline.get("status") == "enabling":
+                content = self.build_content(self.default_pipeline)
+                enabled_napps = self.get_enabled_napps()
+                self.required_napps = enabled_napps & (self.subscribed_napps)
+                # Added 'error' so flows are not requested again
+                self.required_napps.add('error')
+                self.emit_event('enable_table', content=content)
+                self.pipeline_controller.disabled_pipeline(pipeline['id'])
+                action = "Return to default pipeline."
+
+            # Error when disabling pipeline
+            # Return to previous enabled pipeline
+            else:
+                pipeline = self.pipeline_controller.get_last_updated()
+                content = self.build_content(pipeline)
+                enabled_napps = self.get_enabled_napps()
+                self.required_napps = enabled_napps & (self.subscribed_napps)
+                # Added 'error' so flows are not requested again
+                self.required_napps.add('error')
+                self.emit_event('enable_table', content=content)
+                self.pipeline_controller.enabled_pipeline(pipeline['id'])
+                action = f"Return to pipeline {pipeline['id']}"
+
+            log.error(f"Could not get the flows from flow_mager. Status "
+                      f"code {response.status_code}. {action}")
+            return None
+        return response.json()
+
     def get_flows_to_be_installed(self):
         """Get flows from flow manager so this NApp can modify them
         Third, install the flows with different table_id"""
@@ -133,98 +167,102 @@ class Main(KytosNApp):
         if pipeline.get("status") == "enabled":
             # Pipeline enabling has finnished already
             return
-        # Keys necessary to delete a flow, 'cookie_mask' is added later
-        keys = {'idle_timeout', 'hard_timeout', 'cookie', 'priority',
-                'match', 'actions'}
-        command = "v2/stored_flows?state=installed"
-        response = requests.get(f"{FLOW_MANAGER_URL}/{command}")
 
-        if response.status_code // 100 != 2:
-            log.error(f"Could not get the flows from flow_mager. Status "
-                      f"code {response.status_code}.")
-            # Problem here: pipeline stays as 'enabling', error needs
-            # to be handled. Events have been sent and NApps are probably
-            # working in a different pipeline setup
+        flows_by_swich = self.get_installed_flows(pipeline)
+        if flows_by_swich is None:
             return
-        if pipeline.get("status") is None:
-            # Changing to default pipeline. Miss flow entries are not needed
-            self.delete_miss_flows()
-        flows_by_swich = response.json()
         set_up = self.build_content(pipeline)
-
+        delete_flows = {}
+        install_flows = {}
         for switch in flows_by_swich:
-            delete_flows = {"flows": []}
-            install_flows = {"flows": []}
+            delete_flows[switch] = []
+            install_flows[switch] = []
             for flow in flows_by_swich[switch]:
-                owner = flow["flow"]["owner"]
+                owner = flow["flow"].get("owner")
                 if owner not in set_up:
                     continue
                 expected_table_id = set_up[owner][flow["flow"]["table_group"]]
                 # if table_id needs to change
                 if expected_table_id != flow["flow"]["table_id"]:
                     # Get key-value from flow to be sent to flow_manager
-                    delete = {key: flow["flow"].get(key) for key in keys}
-                    delete["cookie_mask"] = flow["flow"]["cookie"]
-                    delete_flows["flows"].append(delete.copy())
-
+                    delete = {
+                        'cookie': flow["flow"].get('cookie'),
+                        'cookie_mask': int(0xFFFFFFFFFFFFFFFF),
+                    }
+                    if flow["flow"].get('match'):
+                        delete['match'] = flow["flow"].get('match')
+                    delete_flows[switch].append(delete.copy())
                     # Change table_id before being added
                     flow["flow"].update({"table_id": expected_table_id})
-                    install_flows["flows"].append(flow["flow"].copy())
+                    install_flows[switch].append(flow["flow"].copy())
+        if pipeline.get("status") is None:
+            # Changing to default pipeline. Miss flow entries are not needed
+            self.delete_miss_flows()
+        else:
+            self.install_miss_flows(pipeline)
+        self.send_flows(delete_flows, 'delete', True)
+        self.send_flows(install_flows, 'install', True)
+        if pipeline.get("status"):
+            self.pipeline_controller.enabled_pipeline(pipeline["id"])
 
-            if delete_flows["flows"]:
-                self.send_flows(delete_flows, switch, "delete")
-            if install_flows["flows"]:
-                self.send_flows(install_flows, switch, "add")
-            self.install_miss_flows(pipeline, switch)
-        if pipeline.get('id'):
-            self.pipeline_controller.update_status(pipeline["id"], "enabled")
-
-    def install_miss_flows(self, pipeline: dict, switch: str):
+    def install_miss_flows(self, pipeline: dict):
         """Install miss flow entry to a switch"""
-        install_flows = {"flows": []}
-        cookie = self.get_cookie(switch)
-        for table in pipeline["multi_table"][:-1]:
-            instruction = [{"instruction_type": "goto_table",
-                            "table_id": table['table_id'] + 1}]
-            flow = {
-                'priority': table.get('priority', 0),
-                'cookie': cookie,
-                'instructions': table.get('instructions', instruction),
-                'owner': 'of_multi_table',
-                'table_group': 'base',
-                'table_id': table['table_id'],
-            }
-            if table.get('match'):
-                flow['match'] = table.get('match')
-            install_flows["flows"].append(flow)
-
-        if install_flows["flows"]:
-            self.send_flows(install_flows, switch, "add")
+        install_flows = {}
+        for switch in self.controller.switches:
+            install_flows[switch] = []
+            cookie = self.get_cookie(switch)
+            for table in pipeline["multi_table"]:
+                miss_flow = table.get("table_miss_flow")
+                if miss_flow:
+                    flow = {
+                        'priority': miss_flow.get('priority', 0),
+                        'cookie': cookie,
+                        'owner': 'of_multi_table',
+                        'table_group': 'base',
+                        'table_id': table['table_id'],
+                    }
+                    if miss_flow.get('match'):
+                        flow['match'] = miss_flow.get('match')
+                    instruction = miss_flow.get('instructions')
+                    if instruction and instruction[0]:
+                        flow['instructions'] = miss_flow.get('instructions')
+                    install_flows[switch].append(flow)
+        self.send_flows(install_flows, 'install', True)
 
     def delete_miss_flows(self):
         """Delete miss flows, aka. of_multi_table flows.
         This method is called when returning to default pipeline."""
-        flows = {
-          "flows": [
-            {
-              "cookie": 12465963768561532928,
-              "cookie_mask": 18374686479671623680
-            }
-          ]
+        flow = {
+            "cookie": int(COOKIE_PREFIX << 56),
+            "cookie_mask": int(0xFF00000000000000)
         }
-        self.send_flows(flows, '', 'delete')
+        delete_flows = {}
+        for switch in self.controller.switches:
+            delete_flows[switch] = [flow]
+        self.send_flows(delete_flows, 'delete', True)
 
-    def send_flows(self, flows: Dict[str, list], switch: str, action: str):
-        """Send flows to flow manager to be added or deleted"""
-        url = f"{FLOW_MANAGER_URL}/v2/flows/{switch}"
-        if action == 'delete':
-            response = requests.delete(url, json=flows)
-        elif action == 'add':
-            response = requests.post(url, json=flows)
-        if response.status_code // 100 != 2:
-            log.error(f'Flow manager returned an error trying to {action}: '
-                      f'{flows}. Status code {response.status_code}'
-                      f'on switch {switch}')
+    def send_flows(self, flows: Dict, action: str, force: bool):
+        """Send flows to flow_manager through event"""
+        print("BATCH -> ", BATCH_SIZE)
+        while flows:
+            switch = list(flows.keys())
+            for dpid in switch:
+                if len(flows[dpid]) == 0:
+                    del flows[dpid]
+                    continue
+                name = f"kytos.flow_manager.flows.{action}"
+                content = {
+                    'dpid': dpid,
+                    'flow_dict': {"flows": flows[dpid][:BATCH_SIZE]},
+                    'force': force
+                }
+                event = KytosEvent(name=name, content=content)
+                self.controller.buffers.app.put(event)
+                if BATCH_SIZE is None or BATCH_SIZE >= len(flows[dpid]):
+                    del flows[dpid]
+                    continue
+                flows[dpid] = flows[dpid][BATCH_SIZE:]
+            time.sleep(BATCH_INTERVAL)
 
     @staticmethod
     def get_pipeline_controller():
@@ -286,16 +324,17 @@ class Main(KytosNApp):
         """Enable pipeline"""
         pipeline_id = request.path_params["pipeline_id"]
         log.debug(f"enable_pipeline /v1/pipeline/{pipeline_id}/enable")
-        pipeline = self.pipeline_controller.update_status(pipeline_id,
-                                                          "enabling")
+        pipeline = self.pipeline_controller.get_pipelines("enabling")
+        if pipeline["pipelines"]:
+            msg = "There is another pipeline enabling already"
+            log.debug(f"enable_pipeline result {msg} 409")
+            raise HTTPException(409, detail=msg)
+        pipeline = self.pipeline_controller.enabling_pipeline(pipeline_id)
         if not pipeline:
             msg = f"Pipeline {pipeline_id} not found"
             log.debug(f"enable_pipeline result {msg} 404")
             raise HTTPException(404, detail=msg)
-        if pipeline.get("error") == "Conflict":
-            msg = "There is another pipeline enabling already"
-            log.debug(f"enable_pipeline result {msg} 409")
-            raise HTTPException(409, detail=msg)
+
         self.load_enable_table(pipeline)
         msg = f"Pipeline {pipeline_id} enabling"
         log.debug(f"enable_pipeline result {msg} 200")
@@ -306,25 +345,30 @@ class Main(KytosNApp):
         """Disable pipeline"""
         pipeline_id = request.path_params["pipeline_id"]
         log.debug(f"disable_pipeline /v1/pipeline/{pipeline_id}/disable")
-        pipeline = self.pipeline_controller.update_status(pipeline_id,
-                                                          "disabled")
+        pipeline = self.pipeline_controller.get_pipelines("enabling")
+        if pipeline["pipelines"] and \
+           pipeline_id != pipeline["pipelines"][0]["id"]:
+            msg = "There is another pipeline being enable, " + \
+                  "please wait for it to finish or disable it."
+            log.debug(f"enable_pipeline result {msg} 409")
+            raise HTTPException(409, detail=msg)
+        pipeline = self.pipeline_controller.disabled_pipeline(pipeline_id)
         if not pipeline:
             msg = f"Pipeline {pipeline_id} not found"
             log.debug(f"disable_pipeline result {msg} 404")
             raise HTTPException(404, detail=msg)
+        if pipeline["status"] != "disabled":
+            # If the recently disabled pipeline was not disabled,
+            # return to default
+            self.enable_default_pipeline()
         msg = f"Pipeline {pipeline_id} disabled"
-        self.enable_basic_pipeline()
         log.debug(f"disable_pipeline result {msg} 200")
         return JSONResponse(msg)
 
-    def enable_basic_pipeline(self):
-        """Return to basic pipeline
+    def enable_default_pipeline(self):
+        """Return to default pipeline
         After disabling a pipeline"""
-        content = {
-            'of_lldp': {'base': 0},
-            'coloring': {'base': 0},
-            'mef_eline': {'epl': 0, 'evpl': 0},
-        }
+        content = self.build_content(self.default_pipeline)
         enabled_napps = self.get_enabled_napps()
         self.required_napps = enabled_napps.intersection(self.subscribed_napps)
         self.emit_event('enable_table', content=content)
@@ -337,18 +381,6 @@ class Main(KytosNApp):
     def handle_flow_mod_added(self, event):
         """Handle recently added flows"""
 
-    @listen_to("kytos/of_core.handshake.completed")
-    def on_handshake_completed(self, event):
-        """Listen to new switches added"""
-        self.handle_handshake_completed(event)
-
-    def handle_handshake_completed(self, event):
-        """Handle new added switches"""
-        switch_id = event.content['switch'].dpid
-        pipeline = self.get_enabled_table()
-        if pipeline.get('status') is not None:
-            self.install_miss_flows(pipeline, switch_id)
-
     @listen_to("kytos/flow_manager.flow.error")
     def on_flow_mod_error(self, event):
         """Handle flow mod errors"""
@@ -358,10 +390,10 @@ class Main(KytosNApp):
         """Handle flow mod errors"""
 
     @staticmethod
-    def get_cookie(switch_dpid):
+    def get_cookie(switch_dpid) -> int:
         """Return the cookie integer given a dpid."""
         dpid = int(switch_dpid.replace(":", ""), 16)
-        return (0x000FFFFFFFFFFFFF & dpid) | (COOKIE_PREFIX << 56)
+        return (0x00FFFFFFFFFFFFFF & dpid) | (COOKIE_PREFIX << 56)
 
     @staticmethod
     def error_msg(error_list: list) -> str:

--- a/main.py
+++ b/main.py
@@ -2,17 +2,24 @@
 
 This NApp implements Oplenflow multi tables
 """
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument, too-many-arguments, too-many-public-methods
+# pylint: disable=attribute-defined-outside-init
 import pathlib
+from threading import Lock
+from typing import Dict
 
+import requests
 from pydantic import ValidationError
 
 from kytos.core import KytosNApp, log, rest
-from kytos.core.helpers import load_spec, validate_openapi
+from kytos.core.events import KytosEvent
+from kytos.core.helpers import listen_to, load_spec, validate_openapi
 from kytos.core.rest_api import (HTTPException, JSONResponse, Request,
                                  get_json_or_400)
 
 from .controllers import PipelineController
+from .settings import (BASIC_PIPELINE, COOKIE_PREFIX, FLOW_MANAGER_URL,
+                       SUBSCRIBED_NAPPS)
 
 
 class Main(KytosNApp):
@@ -31,10 +38,193 @@ class Main(KytosNApp):
 
         So, if you have any setup routine, insert it here.
         """
+        self.basic_pipeline = BASIC_PIPELINE
+        self.subscribed_napps = SUBSCRIBED_NAPPS
         self.pipeline_controller = self.get_pipeline_controller()
+        self._pipeline_lock = Lock()
+        self.required_napps = set()
+        self.load_enable_table(self.get_enabled_table())
 
     def execute(self):
         """Execute once when the napp is running."""
+
+    def get_enabled_table(self):
+        """Get the only enabled table, if exists"""
+        pipelines = self.pipeline_controller.get_pipelines("enabling")
+        if pipelines["pipelines"]:
+            return pipelines["pipelines"][0]
+        pipelines = self.pipeline_controller.get_pipelines("enabled")
+        if pipelines["pipelines"]:
+            return pipelines["pipelines"][0]
+        return self.basic_pipeline
+
+    def load_enable_table(self, pipeline: dict):
+        """If a pipeline was received, set 'self' variables"""
+        if not (pipeline.get('status') in {'enabled', 'enabling'}):
+            return
+
+        found_napps = set()
+        content = self.build_content(pipeline)
+        enable_napps = self.get_enabled_napps()
+        # Find NApps in the pipeline to notify them
+        for napp in content:
+            if napp in enable_napps:
+                found_napps.add(napp)
+        self.required_napps = found_napps
+        self.start_enabling_pipeline(content)
+
+    def get_enabled_napps(self):
+        """Get the NApps that are enabled and subscribed"""
+        enable_napps = set()
+        for key in self.controller.napps:
+            # Keys look like this: ('kytos', 'of_lldp')
+            if key[1] in self.subscribed_napps:
+                enable_napps.add(key[1])
+        return enable_napps
+
+    def start_enabling_pipeline(self, content: dict):
+        """Method to start the process to enable table
+        First, send event notifying NApps about their
+        new table set up.
+        """
+        name = "enable_table"
+        self.emit_event(name, content)
+
+    def build_content(self, pipeline: dict):
+        """Build content to be sent through an event"""
+        content = {}
+        with self._pipeline_lock:
+            for table in pipeline["multi_table"]:
+                table_id = table["table_id"]
+                for napp in table["napps_table_groups"]:
+                    if napp not in content:
+                        content[napp] = {}
+                    for flow_type in table["napps_table_groups"][napp]:
+                        content[napp][flow_type] = table_id
+        return content
+
+    def emit_event(self, name: str, content: dict = None):
+        """Send event"""
+        context = "kytos/of_multi_table"
+        event_name = f"{context}.{name}"
+        event = KytosEvent(name=event_name, content=content)
+        self.controller.buffers.app.put(event)
+
+    @listen_to("kytos/(mef_eline|coloring|of_lldp).enable_table")
+    def on_enable_table(self, event):
+        """Listen for NApps responses"""
+        self.handle_enable_table(event)
+
+    def handle_enable_table(self, event):
+        """Handle NApps responses from enable_table
+        Second, wait for all the napps to respond"""
+        napp = event.name.split('/')[1].split('.')[0]
+        # Check against the last current table
+        self.required_napps.remove(napp)
+        if self.required_napps:
+            # There are more required napps, 'waiting' responses
+            return
+        self.get_flows_to_be_installed()
+
+    def get_flows_to_be_installed(self):
+        """Get flows from flow manager so this NApp can modify them
+        Third, install the flows with different table_id"""
+        pipeline = self.get_enabled_table()
+        if pipeline.get("status") == "enabled":
+            # Pipeline enabling has finnished already
+            return
+        # Keys necessary to delete a flow, 'cookie_mask' is added later
+        keys = {'idle_timeout', 'hard_timeout', 'cookie', 'priority',
+                'match', 'actions'}
+        command = "v2/stored_flows?state=installed"
+        response = requests.get(f"{FLOW_MANAGER_URL}/{command}")
+
+        if response.status_code // 100 != 2:
+            log.error(f"Could not get the flows from flow_mager. Status "
+                      f"code {response.status_code}.")
+            # Problem here: pipeline stays as 'enabling', error needs
+            # to be handled. Events have been sent and NApps are probably
+            # working in a different pipeline setup
+            return
+        if pipeline.get("status") is None:
+            # Changing to default pipeline. Miss flow entries are not needed
+            self.delete_miss_flows()
+        flows_by_swich = response.json()
+        set_up = self.build_content(pipeline)
+
+        for switch in flows_by_swich:
+            delete_flows = {"flows": []}
+            install_flows = {"flows": []}
+            for flow in flows_by_swich[switch]:
+                owner = flow["flow"]["owner"]
+                if owner not in set_up:
+                    continue
+                expected_table_id = set_up[owner][flow["flow"]["table_group"]]
+                # if table_id needs to change
+                if expected_table_id != flow["flow"]["table_id"]:
+                    # Get key-value from flow to be sent to flow_manager
+                    delete = {key: flow["flow"].get(key) for key in keys}
+                    delete["cookie_mask"] = flow["flow"]["cookie"]
+                    delete_flows["flows"].append(delete.copy())
+
+                    # Change table_id before being added
+                    flow["flow"].update({"table_id": expected_table_id})
+                    install_flows["flows"].append(flow["flow"].copy())
+
+            if delete_flows["flows"]:
+                self.send_flows(delete_flows, switch, "delete")
+            if install_flows["flows"]:
+                self.send_flows(install_flows, switch, "add")
+            self.install_miss_flows(pipeline, switch)
+        if pipeline.get('id'):
+            self.pipeline_controller.update_status(pipeline["id"], "enabled")
+
+    def install_miss_flows(self, pipeline: dict, switch: str):
+        """Install miss flow entry to a switch"""
+        install_flows = {"flows": []}
+        cookie = self.get_cookie(switch)
+        for table in pipeline["multi_table"][:-1]:
+            instruction = [{"instruction_type": "goto_table",
+                            "table_id": table['table_id'] + 1}]
+            flow = {
+                'priority': table.get('priority', 0),
+                'cookie': cookie,
+                'instructions': table.get('instructions', instruction),
+                'owner': 'of_multi_table',
+                'table_group': 'base',
+                'table_id': table['table_id'],
+            }
+            if table.get('match'):
+                flow['match'] = table.get('match')
+            install_flows["flows"].append(flow)
+
+        if install_flows["flows"]:
+            self.send_flows(install_flows, switch, "add")
+
+    def delete_miss_flows(self):
+        """Delete miss flows, aka. of_multi_table flows.
+        This method is called when returning to default pipeline."""
+        flows = {
+          "flows": [
+            {
+              "cookie": 12465963768561532928,
+              "cookie_mask": 18374686479671623680
+            }
+          ]
+        }
+        self.send_flows(flows, '', 'delete')
+
+    def send_flows(self, flows: Dict[str, list], switch: str, action: str):
+        """Send flows to flow manager to be added or deleted"""
+        url = f"{FLOW_MANAGER_URL}/v2/flows/{switch}"
+        if action == 'delete':
+            response = requests.delete(url, json=flows)
+        elif action == 'add':
+            response = requests.post(url, json=flows)
+        if response.status_code // 100 != 2:
+            log.error(f'Flow manager returned an error trying to {action}: '
+                      f'{flows}. Status code {response.status_code}'
+                      f'on switch {switch}')
 
     @staticmethod
     def get_pipeline_controller():
@@ -97,12 +287,17 @@ class Main(KytosNApp):
         pipeline_id = request.path_params["pipeline_id"]
         log.debug(f"enable_pipeline /v1/pipeline/{pipeline_id}/enable")
         pipeline = self.pipeline_controller.update_status(pipeline_id,
-                                                          "enabled")
+                                                          "enabling")
         if not pipeline:
             msg = f"Pipeline {pipeline_id} not found"
             log.debug(f"enable_pipeline result {msg} 404")
             raise HTTPException(404, detail=msg)
-        msg = f"Pipeline {pipeline_id} enabled"
+        if pipeline.get("error") == "Conflict":
+            msg = "There is another pipeline enabling already"
+            log.debug(f"enable_pipeline result {msg} 409")
+            raise HTTPException(409, detail=msg)
+        self.load_enable_table(pipeline)
+        msg = f"Pipeline {pipeline_id} enabling"
         log.debug(f"enable_pipeline result {msg} 200")
         return JSONResponse(msg)
 
@@ -118,8 +313,55 @@ class Main(KytosNApp):
             log.debug(f"disable_pipeline result {msg} 404")
             raise HTTPException(404, detail=msg)
         msg = f"Pipeline {pipeline_id} disabled"
+        self.enable_basic_pipeline()
         log.debug(f"disable_pipeline result {msg} 200")
         return JSONResponse(msg)
+
+    def enable_basic_pipeline(self):
+        """Return to basic pipeline
+        After disabling a pipeline"""
+        content = {
+            'of_lldp': {'base': 0},
+            'coloring': {'base': 0},
+            'mef_eline': {'epl': 0, 'evpl': 0},
+        }
+        enabled_napps = self.get_enabled_napps()
+        self.required_napps = enabled_napps.intersection(self.subscribed_napps)
+        self.emit_event('enable_table', content=content)
+
+    @listen_to("kytos/flow_manager.flow.added")
+    def on_flow_mod_added(self, event):
+        """Looking for recently added flows"""
+        self.handle_flow_mod_added(event)
+
+    def handle_flow_mod_added(self, event):
+        """Handle recently added flows"""
+
+    @listen_to("kytos/of_core.handshake.completed")
+    def on_handshake_completed(self, event):
+        """Listen to new switches added"""
+        self.handle_handshake_completed(event)
+
+    def handle_handshake_completed(self, event):
+        """Handle new added switches"""
+        switch_id = event.content['switch'].dpid
+        pipeline = self.get_enabled_table()
+        if pipeline.get('status') is not None:
+            self.install_miss_flows(pipeline, switch_id)
+
+    @listen_to("kytos/flow_manager.flow.error")
+    def on_flow_mod_error(self, event):
+        """Handle flow mod errors"""
+        self.handle_flow_mod_error(event)
+
+    def handle_flow_mod_error(self, event):
+        """Handle flow mod errors"""
+
+    @staticmethod
+    def get_cookie(switch_dpid):
+        """Return the cookie integer given a dpid."""
+        dpid = int(switch_dpid.replace(":", ""), 16)
+        return (0x000FFFFFFFFFFFFF & dpid) | (COOKIE_PREFIX << 56)
 
     @staticmethod
     def error_msg(error_list: list) -> str:

--- a/openapi.yml
+++ b/openapi.yml
@@ -174,7 +174,6 @@ components:
                 items: 
                   type: string
                   enum:
-                    - base
                     - epl
                     - evpl
               coloring:

--- a/openapi.yml
+++ b/openapi.yml
@@ -209,3 +209,5 @@ components:
             - enabled
             - enabling
             - disabling
+            - enabling_error
+            - disabling_error

--- a/openapi.yml
+++ b/openapi.yml
@@ -130,8 +130,6 @@ components:
         multi_table: {
           "$ref": "#/components/schemas/Pipeline"
         }
-        status:
-          type: string
     
     Pipeline: # Can be referenced via '#/components/schemas/Pipeline'
       type: array
@@ -209,3 +207,5 @@ components:
           enum:
             - disabled
             - enabled
+            - enabling
+            - disabling

--- a/settings.py
+++ b/settings.py
@@ -1,1 +1,15 @@
 """Module with the Constants used in the kytos/of_multi_table."""
+FLOW_MANAGER_URL = "http://localhost:8181/api/kytos/flow_manager"
+COOKIE_PREFIX = 0xad
+
+# NApps that push flows and are subscribed to enable_table event
+SUBSCRIBED_NAPPS = {"coloring", "of_lldp", "mef_eline"}
+
+BASIC_PIPELINE = {"multi_table": [{
+    "table_id": 0,
+    "napps_table_groups": {
+        "coloring": ["base"],
+        "of_lldp": ["base"],
+        "mef_eline": ["evpl", "epl"]
+        }
+    }]}

--- a/settings.py
+++ b/settings.py
@@ -5,7 +5,7 @@ COOKIE_PREFIX = 0xad
 # NApps that push flows and are subscribed to enable_table event
 SUBSCRIBED_NAPPS = {"coloring", "of_lldp", "mef_eline"}
 
-BASIC_PIPELINE = {"multi_table": [{
+DEFAULT_PIPELINE = {"multi_table": [{
     "table_id": 0,
     "napps_table_groups": {
         "coloring": ["base"],
@@ -13,3 +13,12 @@ BASIC_PIPELINE = {"multi_table": [{
         "mef_eline": ["evpl", "epl"]
         }
     }]}
+
+# BATCH_INTERVAL: time interval between batch requests that will be sent to
+# flow_manager (in seconds) - zero enable sending all the requests in a row
+BATCH_INTERVAL = 0.5
+
+# BATCH_SIZE: size of a batch request that will be sent to flow_manager, in
+# number of FlowMod requests. Use 0 (zero) to disable BATCH mode, i.e. sends
+# everything at a glance
+BATCH_SIZE = 50

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
 linters=pylint,pycodestyle,isort
-pylint args = --disable=too-few-public-methods,too-many-instance-attributes,no-name-in-module,unnecessary-pass --ignored-modules=napps.amlight.coloring
+pylint args = --disable=too-few-public-methods,too-many-instance-attributes,no-name-in-module,unnecessary-pass,missing-timeout --ignored-modules=napps.amlight.coloring
 
 
 [isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
 linters=pylint,pycodestyle,isort
-pylint args = --disable=too-few-public-methods,too-many-instance-attributes,no-name-in-module,unnecessary-pass,missing-timeout --ignored-modules=napps.amlight.coloring
+pylint args = --disable=too-few-public-methods,too-many-instance-attributes,no-name-in-module,unnecessary-pass --ignored-modules=napps.amlight.coloring
 
 
 [isort]

--- a/status.py
+++ b/status.py
@@ -1,0 +1,13 @@
+"""Defined status for pipeline"""
+from enum import Enum
+
+
+class PipelineStatus(Enum):
+    """Enum for pipeline status"""
+
+    ENABLED = "enabled"
+    ENABLING = "enabling"
+    ENABLING_ERROR = "enabling_error"
+    DISABLED = "disabled"
+    DISABLING = "disabling"
+    DISABLING_ERROR = "disabling_error"

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -74,10 +74,10 @@ class TestController():
         assert args[1]["$set"]["status"] == "disabled"
 
         self.controller.update_status("pipeline_id", "enabled")
-        assert self.controller.db.pipelines.find_one_and_update.call_count == 3
+        assert self.controller.db.pipelines.find_one_and_update.call_count == 2
         args = self.controller.db.pipelines.find_one_and_update.call_args[0]
-        assert args[0] == {'status': 'enabled', 'id': {'$ne': 'pipeline_id'}}
-        assert args[1]["$set"]["status"] == "disabled"
+        assert args[0] == {"id": "pipeline_id"}
+        assert args[1]["$set"]["status"] == "enabled"
 
     def test_update_status_error(self):
         """Test update_status not found"""

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -45,13 +45,8 @@ class TestController():
     def test_get_active_pipeline(self):
         """Test get_active_pipeline"""
         self.controller.get_active_pipeline()
-        expected_arg = [
-            {"status": 'enabling'},
-            {"status": 'enabled'},
-            {"status": 'disabling'}
-        ]
         args = self.controller.db.pipelines.find_one.call_args[0]
-        assert args[0]['$or'] == expected_arg
+        assert args[0]['status']['$ne'] == "disabled"
 
     def test_get_pipelines(self):
         """Test get pipelines"""

--- a/tests/unit/test_controllers.py
+++ b/tests/unit/test_controllers.py
@@ -42,6 +42,17 @@ class TestController():
         with pytest.raises(ValidationError):
             self.controller.insert_pipeline({})
 
+    def test_get_active_pipeline(self):
+        """Test get_active_pipeline"""
+        self.controller.get_active_pipeline()
+        expected_arg = [
+            {"status": 'enabling'},
+            {"status": 'enabled'},
+            {"status": 'disabling'}
+        ]
+        args = self.controller.db.pipelines.find_one.call_args[0]
+        assert args[0]['$or'] == expected_arg
+
     def test_get_pipelines(self):
         """Test get pipelines"""
         self.controller.get_pipelines()
@@ -81,6 +92,14 @@ class TestController():
         args = self.controller.db.pipelines.find_one_and_update.call_args[0]
         assert args[0] == {"id": "pipeline_id"}
         assert args[1]["$set"]["status"] == "enabled"
+
+    def test_disabling_pipeline(self):
+        """Test disabling_pipeline"""
+        self.controller.disabling_pipeline("pipeline_id")
+        assert self.controller.db.pipelines.find_one_and_update.call_count == 1
+        args = self.controller.db.pipelines.find_one_and_update.call_args[0]
+        assert args[0] == {"id": "pipeline_id"}
+        assert args[1]["$set"]["status"] == "disabling"
 
     def test_disabled_pipeline(self):
         """Test disabled_pipeline"""

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -1,5 +1,7 @@
 """Tests for DB models"""
+import pytest
 from db.models import PipelineBaseDoc
+from pydantic import ValidationError
 
 
 class TestDBModels():
@@ -37,3 +39,49 @@ class TestDBModels():
         assert multi_table.napps_table_groups["of_lldp"] == ["base"]
         assert table_miss_flow.priority == 0
         assert len(table_miss_flow.instructions) == 1
+
+    def test_validate_table_group(self):
+        """Test validate table group"""
+        pipeline = {"multi_table": [
+            {
+                "table_id": 0,
+                "table_miss_flow": {
+                    "priority": 0,
+                    "instructions": [{
+                        "instruction_type": "goto_table",
+                        "table_id": 1
+                    }]
+                },
+            },
+            {
+                "table_id": 1,
+                "table_miss_flow": {
+                    "priority": 0,
+                    "instructions": [{
+                        "instruction_type": "goto_table",
+                        "table_id": 1
+                    }]
+                }
+            }
+        ]}
+        with pytest.raises(ValidationError):
+            PipelineBaseDoc(**pipeline)
+
+    def test_validate_intructions(self):
+        """Test validate instructions"""
+        pipeline = {"multi_table": [
+            {
+                "table_id": 0,
+                "napps_table_groups": {
+                    "mef_eline": ["epl"]
+                }
+            },
+            {
+                "table_id": 1,
+                "napps_table_groups": {
+                    "mef_eline": ["evpl", "epl"]
+                }
+            }
+        ]}
+        with pytest.raises(ValidationError):
+            PipelineBaseDoc(**pipeline)

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -85,3 +85,12 @@ class TestDBModels():
         ]}
         with pytest.raises(ValidationError):
             PipelineBaseDoc(**pipeline)
+
+    def test_validate_table_id(self):
+        """Test validate table id"""
+        pipeline = {"multi_table": [
+            {"table_id": 1},
+            {"table_id": 1}
+        ]}
+        with pytest.raises(ValidationError):
+            PipelineBaseDoc(**pipeline)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,7 +1,8 @@
 """Test the Main class"""
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, call
 
 from pydantic import BaseModel, ValidationError
+from kytos.core.events import KytosEvent
 from kytos.lib.helpers import get_controller_mock, get_test_client
 from napps.kytos.of_multi_table.main import Main
 
@@ -16,6 +17,233 @@ class TestMain:
         self.napp = Main(controller)
         self.api_client = get_test_client(controller, self.napp)
         self.base_endpoint = "kytos/of_multi_table/v1"
+
+    async def test_get_enabled_table(self):
+        """Test get the enabled table"""
+        controller = self.napp.pipeline_controller
+        controller.get_pipelines.return_value = {"pipelines": ["test"]}
+        assert self.napp.get_enabled_table() == "test"
+        controller.get_pipelines.return_value = {"pipelines": []}
+        assert self.napp.get_enabled_table() == self.napp.default_pipeline
+
+    @patch("napps.kytos.of_multi_table.main.Main.start_enabling_pipeline")
+    @patch("napps.kytos.of_multi_table.main.Main.get_enabled_napps")
+    @patch("napps.kytos.of_multi_table.main.Main.build_content")
+    async def test_load_enable_table(self, *args):
+        """Test load an enabled table"""
+        (mock_content, mock_napps, mock_enabling) = args
+        # Default pipeline activation is not from here
+        self.napp.load_enable_table({'id': 'mocked_defaul_pipeline'})
+        assert mock_enabling.call_count == 0
+
+        content = {
+            'of_lldp': {'base': 0},
+            'coloring': {'base': 0},
+        }
+        mock_content.return_value = content
+        mock_napps.return_value = {'of_lldp'}
+        self.napp.load_enable_table({
+            'id': 'mocked_pipeline',
+            'status': 'enabling'
+        })
+        assert self.napp.required_napps == {'of_lldp'}
+        assert mock_enabling.call_count == 1
+        assert mock_enabling.call_args[0][0] == content
+
+    async def test_get_enabled_napps(self):
+        """Test get the current enabled napps"""
+        self.napp.subscribed_napps = {"mef_eline", "of_lldp"}
+        self.napp.controller.napps = {('kytos', 'mef_eline')}
+        assert self.napp.get_enabled_napps() == {'mef_eline'}
+
+    async def test_start_enabling_pipeline(self):
+        """Test start enabling pipeline"""
+        self.napp.emit_event = MagicMock()
+        content = {'of_lldp': {'base': 0}}
+        self.napp.start_enabling_pipeline(content)
+        args = self.napp.emit_event.call_args[0]
+        assert args[0] == "enable_table"
+        assert args[1] == content
+
+    async def test_build_content(self):
+        """Test build the content of enable_table event"""
+        pipeline = {'multi_table': [
+            {
+                'table_id': 0,
+                'napps_table_groups': {'coloring': ['base']}
+            },
+            {
+                'table_id': 1,
+                'napps_table_groups': {'of_lldp': ['base']}
+            },
+            {
+                'table_id': 2,
+                'napps_table_groups': {'mef_eline': ['epl']}
+            },
+            {
+                'table_id': 3,
+                'napps_table_groups': {'mef_eline': ['evpl']}
+            }
+        ]}
+        expected_content = {
+            'coloring': {'base': 0},
+            'of_lldp': {'base': 1},
+            'mef_eline': {'epl': 2, 'evpl': 3},
+        }
+        assert self.napp.build_content(pipeline) == expected_content
+
+    async def test_emit_event(self):
+        """Test emit event"""
+        controller = self.napp.controller
+        name = "enable_table"
+        self.napp.emit_event(name)
+        assert controller.buffers.app.put.call_count == 1
+
+    @patch("napps.kytos.of_multi_table.main.Main.get_flows_to_be_installed")
+    async def test_handle_enable_table(self, mock_flows_to_be_installed):
+        """Test handle content of enable_table event"""
+        self.napp.required_napps = {'mef_eline', 'of_lldp'}
+        event = MagicMock()
+        event.name = "kytos/mef_eline.enable_table"
+        self.napp.handle_enable_table(event)
+        assert mock_flows_to_be_installed.call_count == 0
+        event.name = "kytos/of_lldp.enable_table"
+        self.napp.handle_enable_table(event)
+        assert mock_flows_to_be_installed.call_count == 1
+
+    @patch("napps.kytos.of_multi_table.main.Main.send_flows")
+    @patch("napps.kytos.of_multi_table.main.Main.install_miss_flows")
+    @patch("napps.kytos.of_multi_table.main.Main.delete_miss_flows")
+    @patch("napps.kytos.of_multi_table.main.Main.get_installed_flows")
+    @patch("napps.kytos.of_multi_table.main.Main.get_enabled_table")
+    async def test_get_flows_to_be_installed(self, *args):
+        """Test get flows from flow manager to be installed"""
+        (mock_table, mock_flows, mock_delete, mock_install, mock_send) = args
+
+        # Default pipeline
+        mock_table.return_value = self.napp.default_pipeline
+        flow_of_lldp = {
+            'flow': {
+                'owner': 'of_lldp',
+                'table_id': 2,
+                'table_group': 'base',
+                'cookie': 123,
+                'match': {'dl_src': 'ee:ee:ee:ee:ee:01'}
+            }
+        }
+        flow_unknown = {'flow': {'owner': 'of_core'}}
+        mock_flows.return_value = {'00:00:00:00:00:00:00:01': [
+            flow_of_lldp, flow_unknown
+        ]}
+
+        self.napp.get_flows_to_be_installed()
+        assert mock_delete.call_count == 1
+        assert mock_install.call_count == 0
+        assert self.napp.pipeline_controller.enabled_pipeline.call_count == 0
+
+        args = mock_send.call_args[0]
+        flow_of_lldp["flow"]["table_id"] = 0
+        assert mock_send.call_count == 2
+        assert args[0]['00:00:00:00:00:00:00:01'][0] == flow_of_lldp['flow']
+        assert args[1] == 'install'
+        assert args[2] is True
+
+        # Enabling pipeline
+        mock_table.return_value = {
+            'multi_table': [{
+                    'table_id': 2,
+                    'napps_table_groups': {'of_lldp': ['base']}
+                }],
+
+            'id': 'mocked_pipeline',
+            'status': 'enabling'
+        }
+        mock_flows.return_value = {'00:00:00:00:00:00:00:01': [flow_of_lldp]}
+        self.napp.get_flows_to_be_installed()
+        assert mock_delete.call_count == 1
+        assert mock_install.call_count == 1
+        assert self.napp.pipeline_controller.enabled_pipeline.call_count == 1
+
+        args = mock_send.call_args[0]
+        flow_of_lldp["flow"]["table_id"] = 2
+        assert mock_send.call_count == 4
+        assert args[0]['00:00:00:00:00:00:00:01'][0] == flow_of_lldp['flow']
+        assert args[1] == 'install'
+        assert args[2] is True
+
+        # Enabled pipeline
+        mock_table.return_value = {'status': 'enabled'}
+        self.napp.get_flows_to_be_installed()
+        assert mock_delete.call_count == 1
+        assert mock_install.call_count == 1
+        assert self.napp.pipeline_controller.enabled_pipeline.call_count == 1
+        assert mock_send.call_count == 4
+
+    @patch("napps.kytos.of_multi_table.main.Main.get_cookie")
+    @patch("napps.kytos.of_multi_table.main.Main.send_flows")
+    async def test_install_miss_flows(self, mock_send, mock_cookie):
+        """Test install miss flows"""
+        pipeline = {
+            'multi_table': [{
+                    'table_id': 2,
+                    'napps_table_groups': {'of_lldp': ['base']},
+                    'table_miss_flow':{
+                        'priority': 10,
+                        'instructions': [{
+                            "instruction_type": "goto_table",
+                            "table_id": 3
+                        }],
+                        'match': {'in_port': 1}
+                    }
+                }],
+            'id': 'mocked_pipeline',
+            'status': 'enabling'
+        }
+        mock_cookie.return_value = 999
+        self.napp.controller.switches = {'00:00:00:00:00:00:00:01'}
+        self.napp.install_miss_flows(pipeline)
+        args = mock_send.call_args[0]
+        expected_arg = {
+            '00:00:00:00:00:00:00:01': [{
+                'priority': 10,
+                'cookie': 999,
+                'owner': 'of_multi_table',
+                'table_group': 'base',
+                'table_id': 2,
+                'match': {'in_port': 1},
+                'instructions': [{
+                    "instruction_type": "goto_table",
+                    "table_id": 3
+                }]
+            }]
+        }
+        assert args[0] == expected_arg
+        assert args[1] == 'install'
+        assert args[2] is True
+
+    @patch("napps.kytos.of_multi_table.main.Main.send_flows")
+    async def test_delete_miss_flows(self, mock_send):
+        """Test delete miss flows"""
+        self.napp.controller.switches = {'00:00:00:00:00:00:00:01'}
+        self.napp.delete_miss_flows()
+        expected_arg = {
+            '00:00:00:00:00:00:00:01': [{
+                "cookie": int(0xad << 56),
+                "cookie_mask": int(0xFF00000000000000)
+            }]
+        }
+        assert mock_send.call_count == 1
+        args = mock_send.call_args[0]
+        assert args[0] == expected_arg
+
+    @patch("time.sleep", return_value=None)
+    @patch("napps.kytos.of_multi_table.main.BATCH_SIZE", 2)
+    async def test_send_flows(self, _):
+        """Test send flows"""
+        self.napp.controller.buffers.app.put = MagicMock()
+        flows = {'01': ['flow1', 'flow2', 'flow3']}
+        self.napp.send_flows(flows, 'install', True)
+        assert self.napp.controller.buffers.app.put.call_count == 2
 
     async def test_add_pipeline(self, event_loop):
         """Test adding a pipeline"""
@@ -114,36 +342,115 @@ class TestMain:
         response = await api.delete(url)
         assert response.status_code == 404
 
-    async def test_enable_pipeline(self):
+    @patch("napps.kytos.of_multi_table.main.Main.load_enable_table")
+    async def test_enable_pipeline(self, mock_load):
         """Test enable a pipeline"""
+        controller = self.napp.pipeline_controller
+        controller.get_pipelines.return_value = {"pipelines": []}
+        controller.enabling_pipeline.return_value = {"id": "pipeline_id"}
         api = get_test_client(self.napp.controller, self.napp)
         pipeline_id = "test_id"
         url = f"{self.base_endpoint}/pipeline/{pipeline_id}/enable"
         response = await api.post(url)
         assert response.status_code == 200
+        assert mock_load.call_count == 1
+        assert mock_load.call_args[0][0] == {"id": "pipeline_id"}
 
     async def test_enable_pipeline_not_found(self):
         """Test enable a pipeline not found"""
-        self.napp.pipeline_controller.update_status.return_value = {}
+        controller = self.napp.pipeline_controller
+        controller.get_pipelines.return_value = {"pipelines": []}
+        controller.enabling_pipeline.return_value = {}
         api = get_test_client(self.napp.controller, self.napp)
         pipeline_id = "test_id"
         url = f"{self.base_endpoint}/pipeline/{pipeline_id}/enable"
         response = await api.post(url)
         assert response.status_code == 404
 
-    async def test_disable_pipeline(self):
-        """Test disable a pipeline"""
+    async def test_enable_pipeline_conflict(self):
+        """Test enable a pipeline conflict"""
+        controller = self.napp.pipeline_controller
+        controller.get_pipelines.return_value = {"pipelines": [{
+            "id": "pipeline_enabling"
+        }]}
         api = get_test_client(self.napp.controller, self.napp)
         pipeline_id = "test_id"
+        url = f"{self.base_endpoint}/pipeline/{pipeline_id}/enable"
+        response = await api.post(url)
+        assert response.status_code == 409
+
+    @patch("napps.kytos.of_multi_table.main.Main.enable_default_pipeline")
+    async def test_disable_pipeline(self, mock_enable_default):
+        """Test disable a pipeline"""
+        controller = self.napp.pipeline_controller
+        controller.get_pipelines.return_value = {"pipelines": []}
+        controller.disabled_pipeline.return_value = {"status": "enabled"}
+        pipeline_id = "test_id"
+        api = get_test_client(self.napp.controller, self.napp)
         url = f"{self.base_endpoint}/pipeline/{pipeline_id}/disable"
         response = await api.post(url)
         assert response.status_code == 200
+        assert mock_enable_default.call_count == 1
+
+        # Disable the enabling pipeline
+        controller.get_pipelines.return_value = {"pipelines": [{
+            "id": "test_id"
+        }]}
+        api = get_test_client(self.napp.controller, self.napp)
+        url = f"{self.base_endpoint}/pipeline/{pipeline_id}/disable"
+        response = await api.post(url)
+        assert response.status_code == 200
+        assert mock_enable_default.call_count == 2
 
     async def test_disable_pipeline_not_found(self):
         """Test disable a pipeline not found"""
-        self.napp.pipeline_controller.update_status.return_value = {}
+        controller = self.napp.pipeline_controller
+        controller.get_pipelines.return_value = {"pipelines": []}
+        controller.disabled_pipeline.return_value = {}
         api = get_test_client(self.napp.controller, self.napp)
         pipeline_id = "test_id"
         url = f"{self.base_endpoint}/pipeline/{pipeline_id}/disable"
         response = await api.post(url)
         assert response.status_code == 404
+
+    async def test_disable_pipeline_conflict(self):
+        """Test disable a pipeline conflict"""
+        controller = self.napp.pipeline_controller
+        controller.get_pipelines.return_value = {"pipelines": [{
+            "id": "enabling"
+        }]}
+        api = get_test_client(self.napp.controller, self.napp)
+        pipeline_id = "test_id"
+        url = f"{self.base_endpoint}/pipeline/{pipeline_id}/disable"
+        response = await api.post(url)
+        assert response.status_code == 409
+
+    @patch("napps.kytos.of_multi_table.main.Main.get_enabled_napps")
+    @patch("napps.kytos.of_multi_table.main.Main.build_content")
+    async def test_enable_default_pipeline(self, mock_content, mock_napps):
+        """Test test enable default pipeline"""
+        content = {
+            "mef_eline": {"epl": 0, "evpl": 0},
+            "of_lldp": {"base": 0},
+            "coloring": {"base": 0}
+        }
+        mock_content.return_value = content
+        mock_napps.return_value = {"mef_eline", "of_lldp", "of_core"}
+        self.napp.emit_event = MagicMock()
+        self.napp.enable_default_pipeline()
+        assert self.napp.required_napps == {"mef_eline", "of_lldp"}
+        assert self.napp.emit_event.call_count == 1
+        assert self.napp.emit_event.call_args[1] == {"content": content}
+
+    async def test_get_cookie(self):
+        """Test get cookie"""
+        switch = '00:00:00:00:00:00:00:01'
+        assert self.napp.get_cookie(switch) == 12465963768561532929
+
+    async def test_error_msg(self):
+        """Test error message"""
+        # ValidationErro mocked response
+        error_list = [{'loc': ('table_id', ), 'msg': 'mock_msg_1'}]
+        actual_msg = self.napp.error_msg(error_list)
+        expected_msg = 'table_id: mock_msg_1'
+        assert actual_msg == expected_msg


### PR DESCRIPTION
Closes #4 

### Summary

Added listener methods

Added pipeline installation process. There are few additions to the process:
- New `status` to pipelines, `enabling`. This value indicates that the pipeline is in process to be enabled but not finished yet. The status change from `enabling` to `enabled` is done by the code and not the user.

- Added basic pipeline to `settings`, this resembles the pipeline setup before `of_multi_table` installation.

- New 'status' to pipelines, `disabling`. This value indicates that the pipeline is in process to be disabled but not finished yet.

- New added status value `_error` which will be added to the pipeline `status` in case an related to `of_multi_table` has occurred. These can be a miss flows triggered `OFPT_ERROR`.

Other PR are needed to this commit. [mef_eline](https://github.com/kytos-ng/mef_eline/pull/325)(no longer necessary so far), [of_lldp](https://github.com/kytos-ng/of_lldp/pull/80) and [flow_manager](https://github.com/kytos-ng/flow_manager/pull/150)

### Local Tests

Tested this commit with two different processes in mind:

- Kytos console start: When this NApp starts, the pipeline could be:

1. `enabling`: The enabling of a pipeline did not finished in a previous run. The enabling process will start over again. Flows are still installed by consistency check.
2. `enabled`: This means that a pipeline has been enabled. Only events will be sent to NApps with pipeline setup
3. Default pipeline: Send events with default pipeline setup.
4. `disabling`: A pipeline did not finished the disabling process before. So now the default pipeline is going to be applied.

- Pipeline changed: This is triggered by Requests. The pipeline change could be:

1. Default - Enabling - Enabled: This process is started by `"/v1/pipeline/{pipeline_id}/enable" POST`.
    - Update: Enabling a pipeline can be done even if another pipeline is enabled.
2. Enabled - Disabling - Disabled - Default: This process is started by `"/v1/pipeline/{pipeline_id}/disable" POST`.
    - Update: To rectify default pipeline, the user can try to disable (and all pipelines are disabled) any pipeline and the process of activating a default pipeline will resume

NOTE:
In a case a switch cannot not accept a flow with a certain table id (OFPT_ERROR) has not been tested.