### PR TITLE
feat: added telemetry_int to subscribed napps (same as PR 17)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Subscribed to ``"kytos/telemetry_int.enable_table"`` to support ``telemetry_int``
+
 Changed
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Added
 Changed
 =======
 
-- Replaced ``telemetry_int`` ``base`` table group with ``epl`` and ``evpl``
+- Replaced ``telemetry_int`` ``base`` table group with ``evpl`` and ``epl`` by default using table 2 and 3 respectively
 
 [2023.1.0] - 2023-06-12
 ***********************

--- a/main.py
+++ b/main.py
@@ -117,7 +117,7 @@ class Main(KytosNApp):
         event = KytosEvent(name=event_name, content=content)
         self.controller.buffers.app.put(event)
 
-    @listen_to("kytos/(mef_eline|coloring|of_lldp).enable_table")
+    @listen_to("kytos/(mef_eline|telemetry_int|coloring|of_lldp).enable_table")
     def on_enable_table(self, event):
         """Listen for NApps responses"""
         self.handle_enable_table(event)

--- a/settings.py
+++ b/settings.py
@@ -13,7 +13,7 @@ DEFAULT_PIPELINE = {
                 "coloring": ["base"],
                 "of_lldp": ["base"],
                 "mef_eline": ["evpl", "epl"],
-                "telemetry_int": ["base"],
+                "telemetry_int": ["evpl", "epl"],
             },
         }
     ]

--- a/settings.py
+++ b/settings.py
@@ -3,7 +3,7 @@ FLOW_MANAGER_URL = "http://localhost:8181/api/kytos/flow_manager"
 COOKIE_PREFIX = 0xAD
 
 # NApps that push flows and are subscribed to enable_table event
-SUBSCRIBED_NAPPS = {"coloring", "of_lldp", "mef_eline"}
+SUBSCRIBED_NAPPS = {"coloring", "of_lldp", "mef_eline", "telemetry_int"}
 
 DEFAULT_PIPELINE = {
     "multi_table": [
@@ -13,6 +13,7 @@ DEFAULT_PIPELINE = {
                 "coloring": ["base"],
                 "of_lldp": ["base"],
                 "mef_eline": ["evpl", "epl"],
+                "telemetry_int": ["base"],
             },
         }
     ]

--- a/settings.py
+++ b/settings.py
@@ -26,7 +26,7 @@ DEFAULT_PIPELINE = {
             "napps_table_groups": {
                 "telemetry_int": ["epl"],
             },
-        }
+        },
     ]
 }
 

--- a/settings.py
+++ b/settings.py
@@ -13,7 +13,18 @@ DEFAULT_PIPELINE = {
                 "coloring": ["base"],
                 "of_lldp": ["base"],
                 "mef_eline": ["evpl", "epl"],
-                "telemetry_int": ["evpl", "epl"],
+            },
+        },
+        {
+            "table_id": 2,
+            "napps_table_groups": {
+                "telemetry_int": ["evpl"],
+            },
+        },
+        {
+            "table_id": 3,
+            "napps_table_groups": {
+                "telemetry_int": ["epl"],
             },
         }
     ]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -32,9 +32,20 @@ class TestMain:
                         "coloring": ["base"],
                         "of_lldp": ["base"],
                         "mef_eline": ["evpl", "epl"],
-                        "telemetry_int": ["evpl", "epl"],
                     },
-                }
+                },
+                {
+                    "table_id": 2,
+                    "napps_table_groups": {
+                        "telemetry_int": ["evpl"],
+                    },
+                },
+                {
+                    "table_id": 3,
+                    "napps_table_groups": {
+                        "telemetry_int": ["epl"],
+                    },
+                },
             ]
         }
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -18,6 +18,26 @@ class TestMain:
         self.napp.controller.switches = {"00:00:00:00:00:00:00:01"}
         self.base_endpoint = "kytos/of_multi_table/v1"
 
+    def test_default_pipeline(self) -> None:
+        """Test default pipeline value.
+
+        This is to ensure that if settings.DEFAULT_PIPELINE changes
+        then it needs to be updated accordingly.
+        """
+        assert self.napp.default_pipeline == {
+            "multi_table": [
+                {
+                    "table_id": 0,
+                    "napps_table_groups": {
+                        "coloring": ["base"],
+                        "of_lldp": ["base"],
+                        "mef_eline": ["evpl", "epl"],
+                        "telemetry_int": ["evpl", "epl"],
+                    },
+                }
+            ]
+        }
+
     async def test_get_enabled_table(self):
         """Test get the enabled table"""
         controller = self.napp.pipeline_controller


### PR DESCRIPTION
Closes #14 

### Summary

- Added `telemetry_int` NApp to subscribed napps
- This is @Alopalao's [PR 17](https://github.com/kytos-ng/of_multi_table/pull/17), I had to open a new once since I had to revert 9daba69999037b4f4a625c36f94b71f87c2dde7b
- This change will only land after `2023.1` as discussed on PR 17, so I'll leave this as a draft. 

### Local Tests

Not yet

