### PR TITLE
feat: replaced `telemetry_int` `base` with `epl` and `evpl` table groups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+[UNRELEASED] - Under development
+********************************
+
+Changed
+=======
+
+- Replaced ``telemetry_int`` ``base`` table group with ``epl`` and ``evpl``
+
 [2023.1.0] - 2023-06-12
 ***********************
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -166,7 +166,8 @@ components:
                 items: 
                   type: string
                   enum:
-                    - base
+                    - epl
+                    - evpl
               mef_eline:
                 type: array
                 items: 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -16,7 +16,6 @@ class TestMain:
         controller = get_controller_mock()
         self.napp = Main(controller)
         self.napp.controller.switches = {"00:00:00:00:00:00:00:01"}
-        self.api_client = get_test_client(controller, self.napp)
         self.base_endpoint = "kytos/of_multi_table/v1"
 
     async def test_get_enabled_table(self):
@@ -458,7 +457,12 @@ class TestMain:
                             {"instruction_type": "goto_table", "table_id": 1}
                         ],
                     },
-                    "napps_table_groups": {"of_lldp": ["base"]},
+                    "napps_table_groups": {
+                        "of_lldp": ["base"],
+                        "mef_eline": ["epl", "evpl"],
+                        "coloring": ["base"],
+                        "telemetry_int": ["epl", "evpl"],
+                    },
                 },
             ],
         }


### PR DESCRIPTION
Closes #28 

### Summary

- See updated changelog file
- API routes didn't get bumped based on our last discussions regarding bumping or not, plus `base` hasn't been still used yet by `telemetry_int` that our Kytos-ng team owns, so it's OK to break compatibility in this case. 

### Local Tests

- Created a pipeline using `telemetry_int` `epl` and `evpl` table groups:

```
{
    "pipelines": [
        {
            "id": "a72f9a2fcf7744a18e07cb8fb4f2cf32",
            "inserted_at": "2023-10-06T16:58:25.572000",
            "updated_at": "2023-10-06T16:58:25.572000",
            "multi_table": [
                {
                    "table_id": 0,
                    "description": "table_zero",
                    "napps_table_groups": {
                        "mef_eline": [
                            "epl",
                            "evpl"
                        ],
                        "coloring": [
                            "base"
                        ],
                        "of_lldp": [
                            "base"
                        ],
                        "telemetry_int": [
                            "epl",
                            "evpl"
                        ]
                    }
                }
            ],
            "status": "disabled"
        }
    ]
}
```

### End-to-End Tests

e2e tests exec with this branch:

```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 242 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 47%]
...                                                                      [ 48%]
tests/test_e2e_14_mef_eline.py x                                         [ 49%]
tests/test_e2e_15_mef_eline.py ..                                        [ 50%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 73%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 76%]
tests/test_e2e_40_sdntrace.py .............                              [ 81%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 220 passed, 6 skipped, 11 xfailed, 5 xpassed, 867 warnings in 11516.72s (3:11:56) =
```
