### PR TITLE
fix: parametrized buffers.app.put timeout during setup()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Changed
 =======
 
 - Replaced ``telemetry_int`` ``base`` table group with ``evpl`` and ``epl`` by default using table 2 and 3 respectively
+- If a KytosEvent can't be put on ``buffers.app`` during ``setup()``, it'll make the NApp to fail to start
 
 [2023.1.0] - 2023-06-12
 ***********************

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -72,13 +72,15 @@ class TestMain:
         }
         mock_content.return_value = content
         mock_napps.return_value = {"of_lldp"}
-        self.napp.load_pipeline(self.napp.default_pipeline)
+        self.napp.load_pipeline(self.napp.default_pipeline, 1)
 
         assert mock_content.call_count == 1
         assert mock_napps.call_count == 1
         assert self.napp.required_napps == {"of_lldp"}
         assert mock_enabling.call_count == 1
         assert mock_enabling.call_args[0][0] == content
+        assert mock_enabling.call_args[0][1] == 1
+        assert self.napp.controller.buffers.app.put.call_count == 1
 
     async def test_get_enabled_napps(self):
         """Test get the current enabled napps"""
@@ -117,8 +119,9 @@ class TestMain:
         self.napp.controller = MagicMock()
         controller = self.napp.controller
         name = "enable_table"
-        self.napp.emit_event(name)
+        self.napp.emit_event(name, event_timeout=2)
         assert controller.buffers.app.put.call_count == 1
+        assert controller.buffers.app.put.call_args[1] == {"timeout": 2}
 
     @patch("napps.kytos.of_multi_table.main.Main.get_flows_to_be_installed")
     async def test_handle_enable_table(self, mock_flows_to_be_installed):


### PR DESCRIPTION
Closes #31

I'll leave this PR as a draft in the meantime until https://github.com/kytos-ng/kytos/issues/423 lands

### Local tests

- Created and enabled a pipeline
- Restarted `kytosd`

```
2023-11-01 11:37:40,332 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:37566 - "POST /api/kytos/of_multi_table/v1/pipeline HTTP/1.1" 201
2023-11-01 11:37:52,501 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:40320 - "GET /api/kytos/of_multi_table/v1/pipeline HTTP/1.1" 200
2023-11-01 11:38:15,047 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:45524 - "POST /api/kytos/of_multi_table/v1/pipeline/e990d3ee8b404d29b8c9fc6fca74112c/e
nable HTTP/1.1" 200
2023-11-01 11:38:15,063 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:45534 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed HTTP/1.1" 200
2023-11-01 11:38:15,064 - INFO [kytos.napps.kytos/of_multi_table] [main.py:207:get_flows_to_be_installed] (thread_pool_app_7) of_multi_table pushing flows, pipeline: {'_id': 'e990d3ee8b4
04d29b8c9fc6fca74112c', 'id': 'e990d3ee8b404d29b8c9fc6fca74112c', 'inserted_at': datetime.datetime(2023, 11, 1, 14, 37, 40, 316000), 'updated_at': datetime.datetime(2023, 11, 1, 14, 38, 
15, 40000), 'multi_table': [{'table_id': 0, 'table_miss_flow': {'priority': 0, 'instructions': [{'instruction_type': 'goto_table', 'table_id': 1}], 'match': {}}, 'description': 'table_ze
ro', 'napps_table_groups': {'coloring': ['base'], 'of_lldp': ['base']}}, {'table_id': 1, 'description': 'table_one', 'napps_table_groups': {'mef_eline': ['epl', 'evpl']}}], 'status': 'enabling'}

```