### PR TITLE
Remove Client Side Batching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Changed
 - Updated python environment installation from 3.9 to 3.11
 - Updated test dependencies
 
+Removed
+=======
+- Removed client side batching with ``BATCH_INTERVAL`` and ``BATCH_SIZE``, now replaced with pacing in ``flow_manager``
+
 [2023.2.0] - 2024-02-16
 ***********************
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ This NApp implements Oplenflow multi tables
 # pylint: disable=unused-argument, too-many-arguments, too-many-public-methods
 # pylint: disable=attribute-defined-outside-init
 import pathlib
-import time
 from typing import Dict, Iterable, Optional
 
 import httpx

--- a/main.py
+++ b/main.py
@@ -331,7 +331,7 @@ class Main(KytosNApp):
                         "dpid": dpid,
                         "flow_dict": {"flows": flows},
                         "force": force,
-                    }
+                    },
                 )
             )
 

--- a/settings.py
+++ b/settings.py
@@ -30,4 +30,3 @@ DEFAULT_PIPELINE = {
         },
     ]
 }
-

--- a/settings.py
+++ b/settings.py
@@ -31,11 +31,3 @@ DEFAULT_PIPELINE = {
     ]
 }
 
-# BATCH_INTERVAL: time interval between batch requests that will be sent to
-# flow_manager (in seconds) - zero enable sending all the requests in a row
-BATCH_INTERVAL = 0.5
-
-# BATCH_SIZE: size of a batch request that will be sent to flow_manager, in
-# number of FlowMod requests. Use 0 (zero) to disable BATCH mode, i.e. sends
-# everything at a glance
-BATCH_SIZE = 50

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -480,8 +480,8 @@ class TestMain:
         event = last_call.args[0]
 
         assert event.name == "kytos.flow_manager.flows.install"
-        assert event.content['dpid'] == '01'
-        assert event.content['flow_dict']['flows'] == ["flow1", "flow2", "flow3"]
+        assert event.content["dpid"] == "01"
+        assert event.content["flow_dict"]["flows"] == ["flow1", "flow2", "flow3"]
 
     async def test_add_pipeline(self):
         """Test adding a pipeline"""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,12 +1,14 @@
 """Test the Main class"""
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import call, MagicMock, patch
 
 from napps.kytos.of_multi_table.main import Main
 from pydantic import ValidationError
 
 from kytos.lib.helpers import get_controller_mock, get_test_client
+
+from kytos.core.events import KytosEvent
 
 
 class TestMain:
@@ -469,13 +471,17 @@ class TestMain:
         assert args[1] == "install"
 
     @patch("time.sleep", return_value=None)
-    @patch("napps.kytos.of_multi_table.main.BATCH_SIZE", 2)
     async def test_send_flows(self, _):
         """Test send flows"""
         self.napp.controller.buffers.app.put = MagicMock()
         flows = {"01": ["flow1", "flow2", "flow3"]}
         self.napp.send_flows(flows, "install", True)
-        assert self.napp.controller.buffers.app.put.call_count == 2
+        last_call = self.napp.controller.buffers.app.put.call_args
+        event = last_call.args[0]
+
+        assert event.name == "kytos.flow_manager.flows.install"
+        assert event.content['dpid'] == '01'
+        assert event.content['flow_dict']['flows'] == ["flow1", "flow2", "flow3"]
 
     async def test_add_pipeline(self):
         """Test adding a pipeline"""


### PR DESCRIPTION
Closes #27

### Summary

Removes client side batching.

### Local Tests

Everything seems to run fine with this patch enabled.

### End-to-End Tests

Will need to run these tests later.