### PR TITLE
Catching exception for out of order napps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,14 @@
+#########
+Changelog
+#########
+All notable changes to the of_multi_table NApp will be documented in this file.
+
 [UNRELEASED] - Under development
 ********************************
+
+Fixed
+=====
+- Fixed exception message when a Napp loads before ``of_multi_table``. Now it logs an ``ERROR`` message instead.
 
 [2024.1.1] - 2024-08-04
 ***********************

--- a/main.py
+++ b/main.py
@@ -128,8 +128,13 @@ class Main(KytosNApp):
         """Handle NApps responses from enable_table
         Second, wait for all the napps to respond"""
         napp = event.name.split("/")[1].split(".")[0]
-        # Check against the last current table
-        self.required_napps.remove(napp)
+        try:
+            self.required_napps.remove(napp)
+        except KeyError:
+            log.error(f"{napp} NApp loaded after pipeline was installed."
+                      " Flow inconsistencies may have appeared.")
+            return
+        # 
         if self.required_napps:
             # There are more required napps, 'waiting' responses
             return
@@ -153,7 +158,7 @@ class Main(KytosNApp):
 
     def get_flows_to_be_installed(self):
         """Get flows from flow manager so this NApp can modify them
-        Third, install the flows with different table_id"""
+        and, install the flows with different table_id"""
         pipeline = self.pipeline_controller.get_active_pipeline()
         if not pipeline or pipeline.get("status") == "enabled":
             # Default or enabled pipeline, not need to get flows

--- a/main.py
+++ b/main.py
@@ -131,10 +131,11 @@ class Main(KytosNApp):
         try:
             self.required_napps.remove(napp)
         except KeyError:
-            log.error(f"{napp} NApp loaded after pipeline was installed."
-                      " Flow inconsistencies may have appeared.")
+            log.error(
+                f"{napp} NApp loaded after pipeline was installed."
+                " Flow inconsistencies may have appeared."
+            )
             return
-        # 
         if self.required_napps:
             # There are more required napps, 'waiting' responses
             return

--- a/main.py
+++ b/main.py
@@ -132,8 +132,10 @@ class Main(KytosNApp):
             self.required_napps.remove(napp)
         except KeyError:
             log.error(
-                f"{napp} NApp loaded after pipeline was installed."
-                " Flow inconsistencies may have appeared."
+                f"{napp} NApp loaded after pipeline was installed. "
+                "Flow inconsistencies may have appeared. "
+                f"Try modifying `kytos.json` from {napp} then restart or 
+                redeploy the pipeline."
             )
             return
         if self.required_napps:

--- a/main.py
+++ b/main.py
@@ -134,8 +134,8 @@ class Main(KytosNApp):
             log.error(
                 f"{napp} NApp loaded after pipeline was installed. "
                 "Flow inconsistencies may have appeared. "
-                f"Try modifying `kytos.json` from {napp} then restart or 
-                redeploy the pipeline."
+                f"Try modifying `kytos.json` from {napp} then restart or "
+                "redeploy the pipeline."
             )
             return
         if self.required_napps:


### PR DESCRIPTION
Closes #38 

### Summary

Catching exception when another NApp is loaded after and logging it as an error.

### Local Tests
Loaded `mef_eline` after `of_multi_table`

### End-to-End Tests
N/A
